### PR TITLE
interpolate vars when using multiple branches

### DIFF
--- a/ci/setup_aws_cli.sh
+++ b/ci/setup_aws_cli.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 set -e
 
+# double interpolate vars when using multiple branches
+if [ "$TRAVIS_BRANCH" != "master" ]; then
+  eval export "AwsCfServiceRoleArn=\$AwsCfServiceRoleArn_$TRAVIS_BRANCH"
+  eval export "AwsTravisAccessKey=\$AwsTravisAccessKey_$TRAVIS_BRANCH"
+  eval export "AwsTravisSecretAccessKey=\$AwsTravisSecretAccessKey_$TRAVIS_BRANCH"
+fi
+
 pip install --upgrade awscli
 mkdir ~/.aws
 echo -e "[default]\nregion=us-east-1\nsource_profile=default\nrole_arn=$AwsCfServiceRoleArn" > ~/.aws/config


### PR DESCRIPTION
Some CI builds will use multiple branches (i.e. develop/uat/prod)
to deploy to multiple aws accounts from one repo.  To accomodate
for that we need to double interpolate the vars to get the
correct value.