### PR TITLE
Fix awscli setup

### DIFF
--- a/ci/setup_aws_cli.sh
+++ b/ci/setup_aws_cli.sh
@@ -1,15 +1,17 @@
 #!/bin/bash
 set -ex
 
-# double interpolate vars when using multiple branches
-if [ "$TRAVIS_BRANCH" != "master" ]; then
+# some projects deploy to multiple AWS accounts, dev/stage/prod/etc..
+# we manage this by using git branches, travis vars and double interpolation
+# of environment variables.
+if [ -z ${TRAVIS_TAG+x} ] && [ ${TRAVIS_BRANCH} != "master" ]; then
   eval export "AwsCfServiceRoleArn=\$AwsCfServiceRoleArn_$TRAVIS_BRANCH"
   eval export "AwsTravisAccessKey=\$AwsTravisAccessKey_$TRAVIS_BRANCH"
   eval export "AwsTravisSecretAccessKey=\$AwsTravisSecretAccessKey_$TRAVIS_BRANCH"
 fi
 
+# setup the awscli with the correct aws account info.
 pip install awscli
 mkdir ~/.aws
 echo -e "[default]\nregion=us-east-1\nsource_profile=default\nrole_arn=$AwsCfServiceRoleArn" > ~/.aws/config
 echo -e "[default]\nregion=us-east-1\naws_access_key_id=$AwsTravisAccessKey\naws_secret_access_key=$AwsTravisSecretAccessKey" > ~/.aws/credentials
-


### PR DESCRIPTION
Travis was double interpolating aws account env vars when
building on tag commits. We don't want that.  On tagged builds
we want it to deploy exactly the same as a build of master branch.