### PR TITLE
Fix awscli setup

### DIFF
--- a/ci/setup_aws_cli.sh
+++ b/ci/setup_aws_cli.sh
@@ -4,7 +4,7 @@ set -ex
 # some projects deploy to multiple AWS accounts, dev/stage/prod/etc..
 # we manage this by using git branches, travis vars and double interpolation
 # of environment variables.
-if [ -z ${TRAVIS_TAG+x} ] && [ ${TRAVIS_BRANCH} != "master" ]; then
+if [[ (-z ${TRAVIS_TAG+x} || ${TRAVIS_TAG} != "") && ${TRAVIS_BRANCH} != "master" ]]; then
   eval export "AwsCfServiceRoleArn=\$AwsCfServiceRoleArn_$TRAVIS_BRANCH"
   eval export "AwsTravisAccessKey=\$AwsTravisAccessKey_$TRAVIS_BRANCH"
   eval export "AwsTravisSecretAccessKey=\$AwsTravisSecretAccessKey_$TRAVIS_BRANCH"


### PR DESCRIPTION
The travis build for BridgeResearcherUI was setting the TRAVIS_TAG
environment variable[1] even though the build was not for a tag.
This made setup_aws_cli.sh[2] skip double interprolation of env vars
causing role_arn[3] to not be set which made the BridgeResearchUI build
to fail.

What we want double interpolation when:
(TRAVIS_TAG is not set OR TRAVIS_TAG is empty) AND
TRAVIS_BRANCH is not master

[1] https://travis-ci.org/Sage-Bionetworks/BridgeResearcherUI/builds/460865390#L554
[2] https://github.com/Sage-Bionetworks/infra-utils/blob/master/ci/setup_aws_cli.sh
[3] https://travis-ci.org/Sage-Bionetworks/BridgeResearcherUI/builds/460865390#L629