### PR TITLE
[IT-553] restrictive access to windows EC2

### DIFF
--- a/aws/associate-jc-system.ps1
+++ b/aws/associate-jc-system.ps1
@@ -1,14 +1,19 @@
-# Associate a Windows EC2 instance with a jumpcloud system group
+# Associate a Windows EC2 instance with a jumpcloud user
 # Usage:
-#   associate-jc-system.ps1 -JcServiceApiKey XXXXXXXXXX -JcSystemsGroupId XXXXXXXXX
+#   associate-jc-system.ps1 -JcServiceApiKey XXXXXXXXXX \
+#           -JcSystemsGroupId XXXXXXXXX -OwnerEmail joe.smith@sagebase.org
+#
+# Note: assumes jq is installed thru choco, https://chocolatey.org/packages/jq
 
 # Get jumpcloud info from flag or env var
 Param(
     [String]$JcSystemsGroupId = $env:JC_SYSTEMS_GROUP_ID,
-    [String]$JcServiceApiKey = $env:JC_SERVICE_API_KEY
+    [String]$JcServiceApiKey = $env:JC_SERVICE_API_KEY,
+    [String]$OwnerEmail = $env:OWNER_EMAIL
 )
 if(-not($JcSystemsGroupId)) { Throw "-JcSystemsGroupId is required" }
 if(-not($JcServiceApiKey)) { Throw "-JcServiceApiKey is required" }
+if(-not($OwnerEmail)) { Throw "-OwnerEmail is required" }
 
 # JC powershell module, https://github.com/TheJumpCloud/support/wiki
 Function InstallPowershellModule() {
@@ -16,15 +21,29 @@ Function InstallPowershellModule() {
   Import-Module -Name JumpCloud -Force
 }
 
-Function AssociateJcSystem() {
+Function ServiceConnect() {
   Connect-JCOnline $JcServiceApiKey -force
-  # assumes jq is installed thru choco, https://chocolatey.org/packages/jq
+}
+
+# Give a user group access to a system
+Function AssociateJcSystem() {
   $JcSystemId = Get-Content $env:ProgramFiles\JumpCloud\Plugins\Contrib\jcagent.conf | jq -r '.systemKey'
+  Write-Host "JcSystemId = $JcSystemId"
   Add-JCSystemGroupMember -SystemID $JcSystemId -ByID -GroupID $JcSystemsGroupId
 }
+
+# Give a user access to a system
+Function UserAccessSystem() {
+  $JcSystemId = Get-Content $env:ProgramFiles\JumpCloud\Plugins\Contrib\jcagent.conf | jq -r '.systemKey'
+  Write-Host "JcSystemId = $JcSystemId"
+  $JcUserId = (Get-JCUser -email $OwnerEmail).id
+  Write-Host "JcUserId = $JcUserId"
+  Add-JCSystemUser -SystemID $JcSystemId -UserId $JcUserId -Administrator $True
+}
+
 
 $env:Path += ";C:\ProgramData\chocolatey\lib\jq\tools"
 
 InstallPowershellModule
-
-AssociateJcSystem
+ServiceConnect
+UserAccessSystem


### PR DESCRIPTION
Instead of giving a group access to a provisioned EC2 we
change to only give the EC2 owner access to the
provisioned instance.