### PR TITLE
[IT-592] add validation of OwnerEmail to stack linter

### DIFF
--- a/ci/lint_stack.sh
+++ b/ci/lint_stack.sh
@@ -22,7 +22,8 @@ print_list() {
 
 # Get existing stack names from local files
 get_local_stack_names() {
-  stack_names=( $(/bin/grep -r -w -h '^stack_name:' ${PATH} | /usr/bin/cut -d':' -f2 | /usr/bin/awk '{$1=$1};1') )
+  # get stack names and strip spaces and tabs from string
+  stack_names=( $(/bin/grep -r -w -h '^stack_name:' ${PATH} | /usr/bin/cut -d':' -f2 | /usr/bin/tr -d '\040\011\042\047') )
 }
 
 # Get existing stack names from cloudformation
@@ -34,14 +35,16 @@ get_cf_stack_names() {
 
 # Get the newly added stack_name
 get_new_stack_name() {
-  local diff_output=$(/usr/bin/git diff HEAD~1 | /bin/grep '^+stack_name:' || true)
-  new_stack_name=${diff_output:13}
+  # get stack name and strip spaces/tabs/new line/carriage return from string
+  local diff_output=$(/usr/bin/git diff --unified=0 HEAD~1 | /bin/grep '^+stack_name:' || true)
+  new_stack_name=$(/usr/bin/cut -d':' -f2 <<< ${diff_output} | /usr/bin/tr -d '\040\011\012\015\042\047')
 }
 
 # Get the OwnerEmail in newly added stack name
 get_owner_email() {
-  local diff_output=$(/usr/bin/git diff HEAD~1 | /bin/grep '^\+[[:space:]][[:space:]]OwnerEmail:' || true)
-  owner_email=$(/usr/bin/cut -d':' -f2 <<<$diff_output | /usr/bin/cut -d'"' -f2)
+  # get stack name and strip spaces/tabs/new line/carriage return from string
+  local diff_output=$(/usr/bin/git diff --unified=0 HEAD~1 | /bin/grep '^\+.*OwnerEmail:' || true)
+  owner_email=$(/usr/bin/cut -d':' -f2 <<< ${diff_output} | /usr/bin/tr -d '\040\011\012\015\042\047')
 }
 
 # Verify new stack_name is unique
@@ -69,7 +72,7 @@ verify_name_constraint() {
 
 # Get the list of new or changed files
 get_diff_files() {
-  local diff_output=$(/usr/bin/git diff --name-only HEAD~1 || true)
+  local diff_output=$(/usr/bin/git diff --name-only HEAD~1 )
   files=($diff_output)
 }
 


### PR DESCRIPTION
Verify that the value for "OwnerEmail" in a sceptre template matches
an existing email in sage jumpcloud so that we can assign systems
to sage staff.