### PR TITLE
Update windows MSVC++ install script

### DIFF
--- a/aws/install-ms-vc.ps1
+++ b/aws/install-ms-vc.ps1
@@ -10,11 +10,20 @@ Function InstallVcRedist() {
 
     # Get and install VC++ 2013 Redistributable package (x86 and x64)
     New-Item $env:TEMP\VcRedist -ItemType Directory -Force
-    $VcList = Get-VcList -Release 2013
+
+    $VcList = Get-VcList -Release 2013 -Architecture x86
     $VcList | Save-VcRedist -ForceWebRequest -Path $env:TEMP\VcRedist
     Install-VcRedist -Silent -Path $env:TEMP\VcRedist -VcList $VcList
+
+    $VcList = Get-VcList -Release 2013 -Architecture x64
+    $VcList | Save-VcRedist -ForceWebRequest -Path $env:TEMP\VcRedist
+    Install-VcRedist -Silent -Path $env:TEMP\VcRedist -VcList $VcList
+
+    # verify installed VC++
     Write-Host "Installed VC++ Distributions: "
     Get-InstalledVcRedist | Select Name, Version, ProductCode
+
 }
 
 InstallVcRedist
+


### PR DESCRIPTION
The jumpcloud agent has been updated from a 32 bit (x86) to
64 bit (x64) app.  The app used to requires 32 MS visual C++
but now it requires the 64 bit version of MSVC++.  The
change to the installer script will install both versions
on windows.