### PR TITLE
Add awscli v2 to the windows path

### DIFF
--- a/aws/tag-instance-volume.ps1
+++ b/aws/tag-instance-volume.ps1
@@ -39,6 +39,6 @@ Function TagRootVolume() {
         Key=OwnerEmail,Value=$OwnerEmail
 }
 
-$env:Path += ";$env:ProgramFiles\Amazon\AWSCLIV2\bin;$env:ProgramFiles\Amazon\AWSCLI\bin"
+$env:Path += ";$env:ProgramFiles\Amazon\AWSCLIV2;$env:ProgramFiles\Amazon\AWSCLI\bin"
 
 TagRootVolume

--- a/aws/tag-instance-volume.ps1
+++ b/aws/tag-instance-volume.ps1
@@ -39,6 +39,6 @@ Function TagRootVolume() {
         Key=OwnerEmail,Value=$OwnerEmail
 }
 
-$env:Path += ";$env:ProgramFiles\Amazon\AWSCLI\bin"
+$env:Path += ";$env:ProgramFiles\Amazon\AWSCLIV2\bin;$env:ProgramFiles\Amazon\AWSCLI\bin"
 
 TagRootVolume


### PR DESCRIPTION
AWS officially released awcli v2 and the chocolatey package
maintainer followed suit[1].  When v2 is installed it gets
put into C:\Program Files\Amazon\AWSCLIV2 directory which
means we need to add a path to this new directory.

[1] https://chocolatey.org/packages/awscli#comment-4811995215