### PR TITLE
Derive OWNER_EMAIL from aws:servicecatalog:provisioningPrincipalArn

### DIFF
--- a/aws/set_env_vars_file.ps1
+++ b/aws/set_env_vars_file.ps1
@@ -33,7 +33,8 @@ Function SetEnvVars() {
 
   $DEPARTMENT = ExtractTagValue -KeyName Department
   $PROJECT = ExtractTagValue -KeyName Project
-  $OWNER_EMAIL = ExtractTagValue -KeyName OwnerEmail
+  $PROVISIONING_PRINCIPAL_ARN = ExtractTagValue -KeyName 'aws:servicecatalog:provisioningPrincipalArn'
+  $OWNER_EMAIL = $PROVISIONING_PRINCIPAL_ARN -replace '.*\/'
 
   $FileString = @"
     `$env:AWS_REGION` = "$AWS_REGION"


### PR DESCRIPTION
Make similar change to script used for Windows instances that was made for the Linux instances -- derive the owner email from the provisioning principal tag set by the Service Catalog.