### PR TITLE
[SC-402] pin jumpcloud powershell module version

### DIFF
--- a/aws/associate-jc-system.ps1
+++ b/aws/associate-jc-system.ps1
@@ -17,7 +17,8 @@ if(-not($SynapseUserId)) { Throw "-SynapseUserId is required" }
 
 # JC powershell module, https://github.com/TheJumpCloud/support/wiki
 Function InstallPowershellModule() {
-  Install-Module -Name JumpCloud -Force
+  # pin version due to https://github.com/TheJumpCloud/support/issues/443
+  Install-Module -Name JumpCloud -RequiredVersion 2.0.2 -Force
   Import-Module -Name JumpCloud -Force
 }
 


### PR DESCRIPTION
We need to pin to the previous release due to a jumpcloud powershell module bug in the latest version.

