### PR TITLE
[SC-402] Update Jumpcloud powershell library

### DIFF
--- a/aws/associate-jc-system.ps1
+++ b/aws/associate-jc-system.ps1
@@ -18,7 +18,7 @@ if(-not($SynapseUserId)) { Throw "-SynapseUserId is required" }
 # JC powershell module, https://github.com/TheJumpCloud/support/wiki
 Function InstallPowershellModule() {
   # pin version due to https://github.com/TheJumpCloud/support/issues/443
-  Install-Module -Name JumpCloud -RequiredVersion 2.0.2 -Force
+  Install-Module -Name JumpCloud -RequiredVersion 2.1.1 -Force
   Import-Module -Name JumpCloud -Force
 }
 


### PR DESCRIPTION
We needed to pin to ver 2.0.2 due to issue SC-402.  The issue has been fixed[1] by Jumpcloud and released in ver 2.1.1

[1] https://github.com/TheJumpCloud/jcapi-powershell/issues/51

