### PR TITLE
[IT-3047] Add scan_ses_bounce_owners.py script

### DIFF
--- a/aws/README.md
+++ b/aws/README.md
@@ -3,6 +3,7 @@
 * [associate-jc-system.ps1](#associate-jc-systemps1)
 * [install-ms-vc.ps1](#install-ms-vcps1)
 * [nuke_bucket.py](#nuke_bucketpy)
+* [scan_ses_bounce_owners.py](#scan_ses_bounce_ownerspy)
 * [set_account_policy.sh](#set_account_policysh)
 * [set_env_vars_file.ps1](#set_env_vars_fileps1)
 * [tag-instance-volume.ps1](#tag-instance-volumeps1)
@@ -40,6 +41,23 @@ To be documented
 ### Usage
 
 To be documented
+
+
+## scan_ses_bounce_owners.py
+
+Get the suppression list from SES, and scan for resources tagged as
+owned by suppressed emails. This is useful for finding resources owned
+by people who have left Sage.
+
+### Dependencies
+
+The following python packages are required:
+
+* boto3
+
+### Usage
+
+AWS_PROFILE=organizations ./scan_ses_bounce_owners.py
 
 
 ## set_account_policy.sh

--- a/aws/scan_ses_bounce_owners.py
+++ b/aws/scan_ses_bounce_owners.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+
+import logging
+import pprint
+
+import boto3
+from botocore.config import Config as BotoConfig
+
+# Set up logging
+logging.basicConfig(level=logging.INFO,
+                    format='%(asctime)s %(levelname)s %(message)s')
+for lib in ["botocore", "urllib3"]:
+    log = logging.getLogger(lib)
+    log.setLevel(logging.WARNING)
+
+# Set up boto clients
+# Use adaptive mode in an attempt to optimize retry back-off
+boto_config = BotoConfig(
+    retries={
+        'mode': 'adaptive',  # default mode is legacy
+    }
+)
+rsc_client = boto3.client('resource-explorer-2', config=boto_config)
+ses_client = boto3.client('sesv2', config=boto_config)
+
+
+def list_suppressed_emails():
+    """
+    Retrieve the SES suppression list and return the list of emails.
+    """
+
+    emails = []
+    suppressed = ses_client.list_suppressed_destinations()
+    for summary in suppressed['SuppressedDestinationSummaries']:
+        emails.append(summary['EmailAddress'])
+    logging.debug(f"Email list: {emails}")
+    return emails
+
+
+def find_owned_arns(owner):
+    """
+    Find all resources tagged with the given owner in the given account.
+    """
+
+    arns = []
+    rsc_query = f'tag.value="{owner}"'
+    rsc_search = rsc_client.get_paginator('search')
+    for page in rsc_search.paginate(QueryString=rsc_query):
+        for resource in page['Resources']:
+            logging.debug(f"Found  {resource['OwningAccountId']}  {resource['Arn']}")
+            arns.append(resource['Arn'])
+    return arns
+
+
+if __name__ == '__main__':
+    email_list = list_suppressed_emails()
+    if not email_list:
+        logging.info("No suppressed emails")
+    else:
+        results = {}
+        for email in email_list:
+            logging.debug(f"Searching for {email}")
+            owned = find_owned_arns(email)
+            if owned:
+                results[email] = owned
+
+        if not results:
+            logging.info("No resources found for any email")
+        else:
+            pprint.pp(results)


### PR DESCRIPTION
Add a script that retrieves the list of suppressed emails from SES, and uses resource explorer to find all resources tagged as owned by the suppressed emails. This is useful for finding resources owned by people who have left Sage.