### PR TITLE
[IT-5063] Allow repo admins to bypass our ruleset

### DIFF
--- a/github/create_org_ruleset.py
+++ b/github/create_org_ruleset.py
@@ -48,9 +48,9 @@ RULESET = {
     # Who is allowed to bypass these rules?
     # Remove entries or leave empty to allow no bypasses.
     "bypass_actors": [
-        # Allow org admins to bypass
+        # Allow org admins to bypass, actor_id is always 1 for OrganiziationAdmin
         {"actor_id": 1, "actor_type": "OrganizationAdmin", "bypass_mode": "always"},
-        # Allow repo admins to bypass
+        # Allow repo admins to bypass, actor_id 5 == repo admin
         {"actor_id": 5, "actor_type": "RepositoryRole", "bypass_mode": "always"},
     ],
 

--- a/github/create_org_ruleset.py
+++ b/github/create_org_ruleset.py
@@ -3,7 +3,8 @@
 create_org_ruleset.py
 
 Creates an organization-level ruleset in GitHub that applies branch protection
-rules across multiple repositories at once.
+rules across multiple repositories at once. This requires a Team or Enterprise
+organization, free-tier organizations are not supported.
 
 Usage:
     python create_org_ruleset.py
@@ -22,15 +23,8 @@ import requests
 
 # ── Configuration ────────────────────────────────────────────────────────────
 
-GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN", "YOUR_TOKEN_HERE")
-ORG = os.environ.get("GITHUB_ORG", "your-org-name")
-
-# Which repositories to target.
-# Options:
-#   {"type": "all"}                          — every repo in the org
-#   {"type": "named", "names": ["repo-a"]}  — specific repos by name
-#   {"type": "pattern", "patterns": ["*"]}  — glob patterns
-REPO_TARGET = {"type": "all"}
+GITHUB_TOKEN = os.environ["GITHUB_TOKEN"]
+ORG = os.environ.get("GITHUB_ORG", "Sage-Bionetworks")
 
 # Branch patterns this ruleset will protect
 INCLUDE_BRANCH_PATTERNS = [
@@ -55,7 +49,9 @@ RULESET = {
     # Remove entries or leave empty to allow no bypasses.
     "bypass_actors": [
         # Allow org admins to bypass
-        {"actor_id": 1, "actor_type": "OrganizationAdmin", "bypass_mode": "always"}
+        {"actor_id": 1, "actor_type": "OrganizationAdmin", "bypass_mode": "always"},
+        # Allow repo admins to bypass
+        {"actor_id": 5, "actor_type": "RepositoryRole", "bypass_mode": "always"},
     ],
 
     # Which repos & branches this ruleset applies to


### PR DESCRIPTION
Allow repository administrators to bypass our new ruleset, in addition to organization administrators.

Repo admins already have full administrative control over their repos, so
there's no reason to require IT involvement when they need to make a
direct push (e.g. hotfixing a broken deployment pipeline). This extends
bypass permissions to repo admins while keeping the ruleset enforced for
everyone else.